### PR TITLE
ELECTRA support in embedder

### DIFF
--- a/embed/Electra.py
+++ b/embed/Electra.py
@@ -1,0 +1,79 @@
+from torch import Tensor
+from torch import nn
+from transformers import ElectraModel, ElectraTokenizer
+import json
+from typing import Union, Tuple, List, Dict, Optional
+import os
+import numpy as np
+import logging
+
+class ELECTRA(nn.Module):
+    """ELECTRA model to generate token embeddings.
+    Each token is mapped to an output vector from ELECTRA.
+    """
+    def __init__(self, model_name_or_path: str, max_seq_length: int = 128, do_lower_case: Optional[bool] = None, model_args: Dict = {}, tokenizer_args: Dict = {}):
+        super(ELECTRA, self).__init__()
+        self.config_keys = ['max_seq_length', 'do_lower_case']
+        self.do_lower_case = do_lower_case
+
+        if max_seq_length > 510:
+            logging.warning("ELECTRA only allows a max_seq_length of 510 (512 with special tokens). Value will be set to 510")
+            max_seq_length = 510
+        self.max_seq_length = max_seq_length
+
+        if self.do_lower_case is not None:
+            tokenizer_args['do_lower_case'] = do_lower_case
+
+        self.electra = ElectraModel.from_pretrained(model_name_or_path, **model_args)
+        self.tokenizer = ElectraTokenizer.from_pretrained(model_name_or_path, **tokenizer_args)
+
+    def forward(self, features):
+        """Returns token_embeddings, cls_token"""
+        output_states = self.electra(**features)
+        output_tokens = output_states[0]
+        cls_tokens = output_tokens[:, 0, :]  # CLS token is first token
+        features.update({'token_embeddings': output_tokens, 'cls_token_embeddings': cls_tokens, 'attention_mask': features['attention_mask']})
+
+        if self.electra.config.output_hidden_states:
+            hidden_states = output_states[2]
+            features.update({'all_layer_embeddings': hidden_states})
+
+        return features
+
+    def get_word_embedding_dimension(self) -> int:
+        return self.electra.config.hidden_size
+
+    def tokenize(self, text: str) -> List[int]:
+        """
+        Tokenizes a text and maps tokens to token-ids
+        """
+        return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
+
+    def get_sentence_features(self, tokens: List[int], pad_seq_length: int):
+        """
+        Convert tokenized sentence in its embedding ids, segment ids and mask
+        :param tokens:
+            a tokenized sentence
+        :param pad_seq_length:
+            the maximal length of the sequence. Cannot be greater than self.sentence_transformer_config.max_seq_length
+        :return: embedding ids, segment ids and mask for the sentence
+        """
+        pad_seq_length = min(pad_seq_length, self.max_seq_length) + 3 #Add space for special tokens
+        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt')
+
+
+    def get_config_dict(self):
+        return {key: self.__dict__[key] for key in self.config_keys}
+
+    def save(self, output_path: str):
+        self.electra.save_pretrained(output_path)
+        self.tokenizer.save_pretrained(output_path)
+
+        with open(os.path.join(output_path, 'sentence_electra_config.json'), 'w') as fOut:
+            json.dump(self.get_config_dict(), fOut, indent=2)
+
+    @staticmethod
+    def load(input_path: str):
+        with open(os.path.join(input_path, 'sentence_electra_config.json')) as fIn:
+            config = json.load(fIn)
+        return ELECTRA(model_name_or_path=input_path, **config)

--- a/embed/Embedder.py
+++ b/embed/Embedder.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from Electra import ELECTRA
 from sentence_transformers import models, SentenceTransformer
 
 @dataclass
@@ -6,9 +7,10 @@ class Embedder:
     """
     This class uses Hugging's face transformers library to encode a list of strings into a 768 dim vetor.
     """
-    model_name: str = 'gsarti/scibert-nli'
+    model_name: str = 'gsarti/electra-msmarco-med-cord19-discriminator'
     max_seq_length: int  = 128
     do_lower_case: bool  = True
+    model_type: str = 'electra'
 
     def __post_init__(self):
         self.word_embedding_model = self.get_model()
@@ -18,11 +20,20 @@ class Embedder:
         self.model = SentenceTransformer(modules=[self.word_embedding_model, self.pooling_model])
     
     def get_model(self):
-        return models.BERT(
-            self.model_name,
-            max_seq_length=128,
-            do_lower_case=True
-        )
+        if self.model_type == 'electra':
+            return ELECTRA(
+                self.model_name,
+                max_seq_length=self.max_seq_length,
+                do_lower_case=self.do_lower_case
+            )
+        elif self.model_type == 'bert':
+            return models.BERT(
+                self.model_name,
+                max_seq_length=self.max_seq_length,
+                do_lower_case=self.do_lower_case
+            )
+        else:
+            raise AttributeError("Not supported")
 
     def get_pooling(self):
         return models.Pooling(self.word_embedding_model.get_word_embedding_dimension(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ numpy==1.17.4
 pandas==0.25.3
 elasticsearch==7.6.0
 torch==1.4.0
-sentence_transformers==0.2.5.1
+sentence_transformers==0.2.6.1
 tqdm==4.40.0
 art==4.6
 dataclasses==0.6
+transformers>=2.8.0


### PR DESCRIPTION
- Updated the `Embedder` class with default support for ELECTRA using a custom class in the style of the ones in `sentence_transformers` and the model `gsarti/electra-msmarco-med-cord19-discriminator`

- Fixed `Embedder` to use params when instantiating the word embedding model instead of hardcoded values.

- Updated requirements, `sentence_transformers` > 0.2.6.1 and `transformers` > 2.8.0 both seems to be required for making everything run smoothly (had troubles with 0.2.5.1, probably a bug in `encode`)

Minimal working example:

```python
>>> from Embedder import Embedder
>>> e = Embedder()
>>> type(e.get_model())
<class 'Electra.ELECTRA'>
>>> x = e(["Hello world!", "The intense interest has now somewhat subsided"])
>>> x[0].shape, x[1].shape
((768,), (768,))
```